### PR TITLE
comment page

### DIFF
--- a/src/components/comment/CommentForm.jsx
+++ b/src/components/comment/CommentForm.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import { useDispatch } from "react-redux";
+import { postComment } from "../../redux/modules/commentSlice";
+
+const CommentForm = ({ postId }) => {
+  const [comment, setComment] = useState("");
+  const dispatch = useDispatch();
+
+  // 로그인 유저 정보 세션으로부터 받기
+  const commentId = Math.random();
+  const img =
+    "https://i.pinimg.com/474x/08/c6/d8/08c6d89c4049d7063c0b5b6167cbd566.jpg";
+  const nickname = "moon";
+  const grade = "징징이";
+
+  console.log("comment :>> ", comment);
+
+  const sendData = {
+    postId: postId,
+    comment: comment,
+    img: img,
+    nickname: nickname,
+    grade: grade,
+    createdAt: Date.now(),
+  };
+
+  const post = () => {
+    dispatch(postComment(sendData));
+    setComment("");
+  };
+
+  const onChange = (event) => {
+    return setComment(event.target.value);
+  };
+
+  return (
+    <FormContainer>
+      <TextField
+        id="outlined-start-adornment"
+        name="comment"
+        value={comment}
+        fullWidth
+        onChange={onChange}
+        size="small"
+      />
+      <Button variant="outlined" sx={{ p: 0, ml: 1 }} onClick={post}>
+        댓글 달기
+      </Button>
+    </FormContainer>
+  );
+};
+
+const FormContainer = styled.div`
+  display: flex;
+  margin: 0.4em;
+`;
+
+export default CommentForm;

--- a/src/components/comment/CommentItem.jsx
+++ b/src/components/comment/CommentItem.jsx
@@ -1,0 +1,197 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import Avatar from "@mui/material/Avatar";
+import { useDispatch, useSelector } from "react-redux";
+import { deleteComment, updateComment } from "../../redux/modules/commentSlice";
+
+const CommentItem = ({ commentItem, postId }) => {
+  const { commentId, userId, img, nickname, comment, grade, createdAt } =
+    commentItem;
+  const [updatedComment, setUpdatedComment] = useState(comment);
+  const [visibleEditBtns, setVisibleEditBtns] = useState("block");
+  const [visibleEditCommentBox, setVisibleEditCommentBox] = useState("none");
+
+  const loginUser = "moon"; // 추후 세션 스토리지에서 로그인 정보 가져옴
+
+  const dispatch = useDispatch();
+
+  const getUpdatedComment = (event) => {
+    const text = event.target.value;
+    setUpdatedComment(text);
+  };
+
+  const openUpdateForm = () => {
+    setVisibleEditCommentBox("block");
+    setVisibleEditBtns("none");
+  };
+
+  const cancleEdit = () => {
+    setVisibleEditCommentBox("none");
+    setVisibleEditBtns("block");
+    setUpdatedComment(comment);
+  };
+
+  const updateComment = () => {
+    const sendData = {
+      postId: postId,
+      content: updatedComment,
+    };
+    dispatch(updateComment(sendData));
+  };
+
+  const removeComment = () => {
+    if (window.confirm("삭제 하시겠습니까?")) {
+      dispatch(deleteComment(commentId));
+    } else {
+    }
+  };
+
+  return (
+    <ItemContainer>
+      <Info>
+        <InfoAvatar>
+          <Avatar
+            alt="user_img"
+            src={img}
+            sx={{ width: 28, height: 28, mr: 1 }}
+          />
+          <div>
+            <Nickname>{nickname} &gt; </Nickname>
+            <GradeCreatedAt>
+              <Grade>{grade}</Grade>
+              <CreatedAt>{createdAt}</CreatedAt>
+            </GradeCreatedAt>
+          </div>
+        </InfoAvatar>
+        {loginUser && loginUser === nickname ? (
+          <EditBtns visibleEditBtns={visibleEditBtns}>
+            <UpdateBtn onClick={openUpdateForm}>수정</UpdateBtn>
+            <DeleteBtn onClick={removeComment}>X</DeleteBtn>
+          </EditBtns>
+        ) : (
+          ""
+        )}
+      </Info>
+      <Content visibleEditBtns={visibleEditBtns}>{comment}</Content>
+      <EditedCommentBox visibleEditCommentBox={visibleEditCommentBox}>
+        <EditComment
+          value={updatedComment}
+          onChange={getUpdatedComment}
+        ></EditComment>
+        <EditCommentBtns>
+          <UpdateComplateBtn onClick={updateComment}>
+            수정 완료
+          </UpdateComplateBtn>
+          <CancleBtn onClick={cancleEdit}>취소</CancleBtn>
+        </EditCommentBtns>
+      </EditedCommentBox>
+    </ItemContainer>
+  );
+};
+
+const ItemContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 0.2em 0.4em;
+`;
+
+const Info = styled.div`
+  height: 50px;
+  display: flex;
+  justify-content: space-between;
+  /* background-color: lemonchiffon; */
+  position: relative;
+`;
+
+const InfoAvatar = styled.div`
+  display: flex;
+  align-items: center;
+  /* background-color: lightblue; */
+`;
+
+const Nickname = styled.div`
+  font-size: var(--font-small);
+  color: var(--color-black);
+`;
+
+const Grade = styled.div`
+  font-size: var(--font-micro);
+  color: var(--color-grey);
+`;
+
+const CreatedAt = styled.div`
+  font-size: var(--font-micro);
+  color: var(--color-grey);
+  position: absolute;
+  right: 0px;
+`;
+
+const GradeCreatedAt = styled.div`
+  display: flex;
+  justify-content: space-between;
+  /* background-color: red; */
+  width: 100%;
+`;
+
+const EditBtns = styled.div`
+  display: ${(props) => props.visibleEditBtns};
+`;
+
+const UpdateBtn = styled.div`
+  font-size: var(--font-micro);
+  background-color: var(--color-light-white);
+  padding: 3px 6px;
+  border-radius: 10px;
+  position: absolute;
+  right: 28px;
+  top: 4px;
+`;
+
+const DeleteBtn = styled.div`
+  font-size: var(--font-micro);
+  color: var(--color-white);
+  background-color: var(--color-dark-pink);
+  padding: 3px 6px;
+  border-radius: 10px;
+  position: absolute;
+  right: 3px;
+  top: 4px;
+`;
+
+const EditedCommentBox = styled.div`
+  display: ${(props) => props.visibleEditCommentBox};
+`;
+
+const EditComment = styled.input`
+  width: 100%;
+  margin-bottom: 4px;
+`;
+
+const EditCommentBtns = styled.div`
+  display: flex;
+  justify-content: right; ;
+`;
+
+const UpdateComplateBtn = styled.div`
+  font-size: var(--font-micro);
+  background-color: var(--color-light-white);
+  padding: 3px 6px;
+  border-radius: 10px;
+`;
+
+const CancleBtn = styled.div`
+  font-size: var(--font-micro);
+  color: var(--color-white);
+  background-color: var(--color-dark-pink);
+  padding: 3px 6px;
+  border-radius: 10px;
+  margin-left: 5px;
+`;
+
+const Content = styled.div`
+  width: 100%;
+  font-size: var(--font-small);
+  display: ${(props) => props.visibleEditBtns};
+`;
+
+export default CommentItem;

--- a/src/components/comment/CommentList.jsx
+++ b/src/components/comment/CommentList.jsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import { getComments } from "../../redux/modules/commentSlice";
+import CommentForm from "./CommentForm";
+import CommentItem from "./CommentItem";
+
+const CommentList = ({ postId }) => {
+  const [commentList, setcommentList] = useState("");
+  const dispatch = useDispatch();
+
+  const comments = useSelector((store) => store.comment.comments);
+
+  useEffect(() => {
+    // dispatch(getComments(postId));
+    dispatch(getComments()); // 임시 🐥
+  }, []);
+
+  useEffect(() => {
+    setcommentList(comments);
+  }, [comments]);
+
+  return (
+    <CommentsConatiner>
+      <CommentForm postId={postId} />
+      {commentList &&
+        Array.from(commentList).map((comment) => {
+          return (
+            <CommentItem
+              commentItem={comment}
+              key={comment.commentId}
+              postId={postId}
+            />
+          );
+        })}
+    </CommentsConatiner>
+  );
+};
+
+const CommentsConatiner = styled.div``;
+
+export default CommentList;

--- a/src/components/comment/CommentPage_del.jsx
+++ b/src/components/comment/CommentPage_del.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import CommentList from "./CommentList";
+
+const CommentPage_del = () => {
+  const postId = Math.random();
+  return <CommentList postId={postId} />;
+};
+
+export default CommentPage_del;


### PR DESCRIPTION
## 구현사항
api 연결 전, 임의 값으로 comment 페이지 디자인, 기능 작업

## 요구 조건
- 댓글 생성, 수정, 삭제는 로그인 유저만 가능.
- 로그인 유저와 댓글 작성자가 일치하는 경우 수정, 삭제 아이콘이 보임. 
1. 댓글 보기 (비로그인 유저도 조회 가능) 
    1. 내용, 작성자, 작성자 칭호, 작성일
2. 댓글 생성
3. 댓글 수정
4. 댓글 삭제 (삭제 확인 후 삭제)

## 구현방법
json-server 에 임의값을 넣고 테스트 함.
로그인 정보는 임의값을 넣고 테스트 함.
댓글 수정 (수정 버튼 클릭시 조회 부분이 인풋 창으로 변경 → display 속성으로 조절) 

## etc
댓글 생성 (비로그인 유저가 댓글 작성란 클릭시 로그인 or 회원가입 할꺼냐고 묻기) ⇒ 로그인 기능 완성 후 할 것
api 받고 테스트 해야 함.
상세 페이지 완료 후 다시 테스트 해야 함. ( 상세페이지에 댓글 리스트가 들어감)

