### PR TITLE
채팅 리스트 페이지

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import GoogleRedirect from "./components/login/google/GoogleRedirect";
 import SearchPage from "./pages/SearchPage";
 import NaverRedirect from "./components/login/naver/NaverRedirect";
 import { getCookie } from "./util/cookie";
+import ChatListPage from "./pages/ChatListPage";
 
 const Desktop = ({ children }) => {
   const isDesktop = useMediaQuery({ minWidth: 768 });
@@ -61,6 +62,7 @@ function App() {
             <Route path="/authnaver" element={<NaverRedirect />} />
             <Route path="/search" element={<SearchPage />} />
             <Route path="/chat/:roomId" element={<ChatPage />} />
+            <Route path="/chatlist" element={<ChatListPage />} />
             <Route path="*" element={<div>페이지를 찾을 수 없습니다.</div>} />
           </Routes>
         </Mobile>

--- a/src/components/chat/ChatListItem.jsx
+++ b/src/components/chat/ChatListItem.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styled from "styled-components";
+import Avatar from "@mui/material/Avatar";
+import { useNavigate } from "react-router-dom";
+import { useCookies } from "react-cookie";
+
+const ChatListItem = ({ listItem }) => {
+  const { roomId, userId, profile, nickname, grade, message } = listItem;
+
+  const navigate = useNavigate();
+
+  const chatPage = () => {
+    navigate(`/chat/${roomId}`, {
+      state: {
+        nickname,
+        grade,
+      },
+    });
+  };
+
+  return (
+    <ListItemContainer onClick={chatPage}>
+      <Avatar
+        alt="user_img"
+        src={profile}
+        sx={{ width: 38, height: 38, mr: 1 }}
+      />
+      <ItemContent>
+        <Nickname>
+          {nickname} / {grade}
+        </Nickname>
+        {message}
+      </ItemContent>
+    </ListItemContainer>
+  );
+};
+
+const ListItemContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-orange);
+`;
+
+const Nickname = styled.div`
+  font-size: var(--font-small);
+  color: var(--color-black);
+`;
+
+const ItemContent = styled.div`
+  font-size: var(--font-micro);
+  color: var(--color-grey);
+  width: 100%;
+`;
+
+export default ChatListItem;

--- a/src/components/common/Logo.jsx
+++ b/src/components/common/Logo.jsx
@@ -48,6 +48,10 @@ const Logo = () => {
     } else return;
   };
 
+  const chatList = () => {
+    navigate("/chatlist");
+  };
+
   return (
     <>
       <LogoContainer>zzw.</LogoContainer>
@@ -55,6 +59,7 @@ const Logo = () => {
         <LoginBox>
           {/* <button onClick={unregister}>회원탈퇴</button> */}
           <LogOutText onClick={logout}>Logout</LogOutText>
+          <LogOutText onClick={chatList}>chatList</LogOutText>
         </LoginBox>
       ) : (
         ""

--- a/src/pages/ChatListPage.jsx
+++ b/src/pages/ChatListPage.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import { useState } from "react";
+import { instance } from "../api/request";
+import ChatListItem from "../components/chat/ChatListItem";
+
+const ChatListPage = () => {
+  const [chatList, setChatList] = useState([]);
+
+  useEffect(() => {
+    const getData = async () => {
+      const result = await instance.get(`/api/chat`);
+      if (result.data.success && result.data.erorr === undefined) {
+        setChatList(result.data.data);
+      }
+    };
+    getData();
+  }, []);
+
+  return (
+    <ChatListContainer>
+      <p>DM</p>
+      <ChatList>
+        {chatList.length !== 0 ? (
+          chatList.map((listItem, idx) => (
+            <ChatListItem listItem={listItem} key={idx} />
+          ))
+        ) : (
+          <ListText>채팅 리스트가 없습니다.</ListText>
+        )}
+      </ChatList>
+    </ChatListContainer>
+  );
+};
+
+const ChatListContainer = styled.div`
+  text-align: center;
+  padding: 1rem;
+`;
+
+const ChatList = styled.div`
+  padding: 1rem;
+  text-align: left;
+`;
+
+const ListText = styled.p`
+  padding-top: 2rem;
+`;
+
+export default ChatListPage;


### PR DESCRIPTION
## 구현기능
채팅 리스트 페이지 구현
리스트 항목 클릭시 각 채팅방으로 이동

## 구현방법
리스트의 개수만큼 리스트 아이템을 만들어 줌.
클릭시 네비게이트로 각 채팅방 이동.
네비게이트에 닉네임과 칭호를 실어서 보냄.

## etc